### PR TITLE
readFile closing brackett missing in Classifiation & Object Detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ async function executeAsync(image_filepath) {
 
     const result = await model.executeAsync(data);
     console.log(result);
-  }
+  })
 }
 ```
 
@@ -44,7 +44,7 @@ async function executeAsync(image_filepath) {
 
     const result = await model.executeAsync(data);
     console.log(result);
-  }
+  })
 }
 ```
 


### PR DESCRIPTION
I was working with tfjs and found that in sample code of Object Detection and Classification function the readFile brackett is missing. Updated that in this commit.