### PR TITLE
Updating tfjs-node to v3.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@tensorflow/tfjs-node": "^2.8.3"
+    "@tensorflow/tfjs-node": "^3.12.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR updates tfjs-node to use v3.12.0, which supports Apple Silicon computers.